### PR TITLE
cleanup events and mutation interface a bit more

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -16,9 +16,41 @@ export function CreateClient(services) {
     // Client manages multiple websocket connections and
     // creates/manages models.  The mapping from modelID to the
     // correct websocket URL is provided by the mapper in the
-    // constructor to th service.
+    // constructor to the service.
+    //
+    // Client emits two events:
+    //    localChange has event data = {change, index, before, after}
+    //    remoteChange has event data = {change, index, before, after}
+    //
+    // The actual change is either an array or a single value JSON
+    // structure that represents the change (as per the spec in
+    // https://github.com/dotchain/site/Operation.md).  The index
+    // refers to the first valid index in change.Path.
+    //
+    // Change paths are arrays of strings referring to where in the
+    // JSON model the change happened.  Client tacks on the modelID on
+    // top of it, so someone can watch for all client changes via this
+    // mechanism.
+    //
+    // The before and after fields do not point the before and after
+    // of the client (which being a singleton is not as useful).
+    // Instead, the before/after refer to the ModelManager managing
+    // the model where the change happened.
+    //
+    // Note that calling client.getValue on a change path (that has
+    // the padded modelID) is guaranteed to return the model at that
+    // path.
+    //
+    // A client also supports the apply(event, index, changeOrChanges)
+    // method to apply local or remote changes.  The primary purpose
+    // of this is to apply local changes (as remote changes will
+    // happen via the websocket connection).  Note that local changes
+    // can also be done directly on the model and in either case,
+    // applying local changes will also bubble up the localChange
+    // event.
     return class Client {
         constructor(mapper) {
+            this.events = new services.Events();
             this._log = new services.Log("client: ");
             this._cache = new services.ModelCache();
             this._mapper = mapper;
@@ -27,11 +59,52 @@ export function CreateClient(services) {
             this._conns = {};
         }
 
+        getValue(path) {
+            return this._managers[path[0]].man.getValue(path.slice(1));
+        }
+
+        apply(event, index, change) {
+            if (Array.isArray(change)) {
+                let result = null;
+                change.forEach(ch => (result = this.apply(event, index, ch)));
+                return result;
+            }
+            const path = change.Path;
+            return this._managers[path[index]].man.apply(event, index+1, change);            
+        }
+        
         subscribe(subID, modelID, done) {
-            if (this._managers[subID]) return done(this._managers[subID], subID, modelID);
+            if (this._managers[subID]) return done(this._managers[subID].man, subID, modelID);
+
+            // Propagate manager events up by unshift the current modelID.
+            // Note that before and after refer to the manager, not the client as that is
+            // useless.
+            const propagate = (event, data) => {
+                const newData = Object.assign({}, data, {index: 0});
+                if (Array.isArray(data.change)) {
+                    newData.change = [];
+                    data.change.forEach((ch, idx) => {
+                        newData.change[idx] = fixup(ch);
+                    });
+                } else {
+                    newData.change = fixup(data.change);
+                }
+                this.events.emit(event, newData);
+
+                function fixup(change) {
+                    const newPath = (data.change.Path || []).slice(data.index || 0);
+                    newPath.unshift(modelID);
+                    return Object.assign({}, change, {Path: newPath});
+                }
+            };
             
             const manager = new services.ModelManager(subID, modelID, this._cache, done);
-            this._managers[subID] = manager;
+            const cleanup1 = manager.events.on('localChange', propagate);
+            const cleanup2 = manager.events.on('remoteChange', propagate);
+            this._managers[subID] = {
+                man: manager,
+                cleanup() { cleanup1(), cleanup2(); }
+            };
 
             const url = this._mapper(modelID);
             this._conns[url] = this._conns[url] ||

--- a/client/conn_manager.js
+++ b/client/conn_manager.js
@@ -34,14 +34,14 @@ export function CreateConnectionManager(services) {
         onConnected() {
             this._isConnected = true;
             for (let id in this._subs) {
-                this._managers[id].onConnected(this._conn);
+                this._managers[id].man.onConnected(this._conn);
             }
         }
 
         onDisconnected() {
             this._isConnected = false;
             for (let id in this._subs) {
-                this._managers[id].onDisconnected(this._conn);
+                this._managers[id].man.onDisconnected(this._conn);
             }
         }
 
@@ -51,18 +51,18 @@ export function CreateConnectionManager(services) {
 
         onNotificationResponse(id, ops, ackID) {
             if (!this._subs[id]) return;
-            this._managers[id].onNotificationResponse(ops, ackID);
+            this._managers[id].man.onNotificationResponse(ops, ackID);
         }
 
         onBootstrap(id, rebased, clientRebased) {
             if (!this._subs[id]) return;
-            this._managers[id].onBootstrap(rebased, clientRebased);
+            this._managers[id].man.onBootstrap(rebased, clientRebased);
         }
 
         add(subID, modelID) {
             this._subs[subID] = modelID;
             if (this._connected) {
-                this._managers[subID].onConnected(this._conn);
+                this._managers[subID].man.onConnected(this._conn);
             }
         }
 

--- a/demo/ux/services.js
+++ b/demo/ux/services.js
@@ -12,7 +12,7 @@ import {CreateLog} from '../../client/log.js';
 import {CreateModelCache} from '../../client/model/cache.js';
 import {CreateModelText} from '../../client/model/text.js';
 import {CreateModelArray} from '../../client/model/array.js';
-import {CreateSparseArray} from '../../client/model/sparse.js';
+import {CreateSparseArray} from '../../client/model/sparse_array.js';
 import {CreateModelManager} from '../../client/model/manager.js';
 import {CreateEvents} from '../../client/model/events.js';
 import {CreateRandom} from '../../client/random.js';

--- a/demo/ux/textarea.js
+++ b/demo/ux/textarea.js
@@ -15,8 +15,8 @@ function manageTextArea(elt, onChange) {
     });	    
     return update;
 
-    function update(model) {
-	console.log("New value =", model.value());
-	elt.value = value = model.value();
+    function update(val) {
+	console.log("New value =", val);
+	elt.value = value = val;
     }
 }

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -67,7 +67,7 @@ describe('ModelText tests', () => {
             }            
             m = d.after;
         });
-        const actual = m.applyLocal(change1).applyLocal(change2);
+        const actual = m.apply('localChange', 0, change1).apply('localChange', 0, change2);
         if (actual !== m) {
             return done(new Error("Updated does not match: " + JSON.stringify({expected:m, actual})));
         }
@@ -99,7 +99,7 @@ describe('ModelText tests', () => {
             m = d.after;
         });
 
-        const actual = m.applyLocal(change);
+        const actual = m.apply('localChange', 0, change);
         if (actual !== m) {
             return done(new Error("Updated does not match: " + JSON.stringify({expected:m, actual})));
         }
@@ -119,18 +119,13 @@ describe('ModelText tests', () => {
         done();
     });
 
-    it('applies operations silently', done => {
+    it('applies remoteChanges silently', done => {
         const m = new ModelText("hello world")
-        const ops = [
-            {ID: "one"},
-            {ID: "two", Changes: null},
-            {ID: "three", Changes: []},
-            {ID: "four", Changes: [{}]},
-            {ID: "five", Changes: [{Splice: {Offset: 6, After: "beautiful "}}]},
-        ];
 
         m.events.on("localChange", () => done(new Error("Unexpected callback")));
-        const result = m.applyOperations(ops);
+
+        const changes = [{Path: ['hello'], Splice: {Offset: 6, After: "beautiful "}}];
+        const result = m.apply('remoteChange', 1, changes);
         if (result.value() != "hello beautiful world") {
             done(new Error("Unexpected result: " + result.value()));
         }
@@ -140,7 +135,7 @@ describe('ModelText tests', () => {
     it('throws when attempting to apply a change with a path', done => {
         const m = new ModelText("hello world")
         try {
-            m.applyLocal({Path: ["hello"], Splice: {Offset: 0, After: "x"}})
+            m.apply('localChange', 0, {Path: ["hello"], Splice: {Offset: 0, After: "x"}})
         } catch (e) {
             return done(null);
         }
@@ -150,7 +145,7 @@ describe('ModelText tests', () => {
     it('throws when attempting to apply a set', done => {
         const m = new ModelText("hello world")
         try {
-            m.applyLocal({Set: {}});
+            m.apply('localChange', 0, {Set: {}});
         } catch (e) {
             return done(null);
         }
@@ -160,7 +155,7 @@ describe('ModelText tests', () => {
     it('throws when attempting to apply a range', done => {
         const m = new ModelText("hello world")
         try {
-            m.applyLocal({Range: {}});
+            m.apply('localChange', 0, {Range: {}});
         } catch (e) {
             return done(null);
         }


### PR DESCRIPTION
Mutations can be applied at any level (including top-level multiple-model client)
by calling apply(eventName, index, change)

eventName must be `localChange` or `remoteChange`.  change is a single change or
an array of changes.  index refers to number of levels within change.Path that
has already been processed. This allows the same change object to be passed down
instead of creating a new change object with the truncated path.

The app can also directly mutate a model.  Mutating a model via `apply` results
in its event bubbling up the corresponding event with data set to:

`{change, index, before, after}`

where change is the applied change, and as before `index` refers to the slice of
change.Path that describes where the change happened.  The `before` and `after`
fields indicate the before and after values of the current model being changed.

Note that `localChange` events bubble up (but not remote change events as these
naturally are applied top-down) with the change.Path correspondingly getting
prepended to.  In particular, by the time the event bubbles up to the client
object, it contains the modelID as the first element.

The `before` and `after` fields are good for managing persistent datastructures.
Note that the client and ModelManager (the top level objects) are not really
persistent.  Also, the before/after for a client `localChange` event conveniently
stores the affected ModelManager rather than the singleton client.

It is possible to access a sub-path from any level by calling `getValue(path)`.
In particular, `client.getValue([modelID])` returns the value of the top-level
model. (It does not return the model manager)

These changes are poorly tested as the test infrastructure for testing these is
slowly being built up now.