### PR TITLE
Change slice() to match natural JS semantics

### DIFF
--- a/lib/null.js
+++ b/lib/null.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+'use strict';
+
+// CreateNull is a builder for the Null class
+//
+// All builders take one parameter which is a map of services. This is
+// the dependency injection mechanism.  Builder must return a class.
+// Code that runs directly in the builder must not access any fields
+// of the builder (so it is not possible to extend builder classes)
+// but code within the class (such as the class constructor) can
+// safely acess the services.
+export function CreateNull(services) {
+    // Null represents a null data which can represent actual nulls
+    // or an empty string or a empty array depending on the situation.
+    return class Null {
+        toJSON() {}
+        forEach() {}
+        count() { return 0; }
+        slice(start, end) {
+            if (start === 0 && end === 0) return this;
+            throw new Error("null: slice invalid params: " + [start, end]);
+        }
+
+        rangeApply(offset, count) {
+            if (offset === 0 && count === 0) return this;
+            throw new Error("null: rangeApply invalid params: " + [offset, count]);
+        }
+
+        splice(offset, before, after) {
+            if (offset !== 0 || services.ArrayLike.count(before) !== 0) {
+                throw new Error("null: invalid slice params");
+            }
+            return after;
+        }
+    }
+}

--- a/lib/sparse_array.js
+++ b/lib/sparse_array.js
@@ -47,28 +47,30 @@ export function CreateSparseArray(services) {
             }
         }
 
-        _slice(offset, count) {
-            if (offset < 0 || count < 0) throw new Error("slice: invalid parameter");
+        _slice(start, end) {
+            if (start < 0 || end < start) {
+                throw new Error("slice: invalid parameter: ", [start, end]);
+            }
             let index = 0;
             const elts = [];
             for (let kk = 0; kk < this._elts.length; kk += 2) {
-                const s = Math.max(index, offset);
-                const e = Math.min(index + this._elts[kk], offset + count);
+                const s = Math.max(index, start);
+                const e = Math.min(index + this._elts[kk], end);
                 if (s < e) elts.push(e - s, this._elts[kk+1])
                 index += this._elts[kk];
             }
-            if (index < offset + count) throw new Error("Invalid slice()");
+            if (index < end) throw new Error("Invalid slice()");
             return elts;
         }
 
-        slice(offset, count) {
-            return new SparseArray(make(this._slice(offset, count)));
+        slice(start, end) {
+            return new SparseArray(make(this._slice(start, end)));
         }
 
         splice(offset, before, after) {
+            const count = services.ArrayLike.count(before);
             if (offset < 0 || count < 0) throw new Error("splice: invalid parameter");
 
-            const count = services.ArrayLike.count(before);
             const end = offset + count;
             const e = [];
             const append = elt => {
@@ -89,10 +91,13 @@ export function CreateSparseArray(services) {
         }
 
         rangeApply(offset, count, fn) {
-            const before = this.slice(offset, count);
+            const before = this.slice(offset, offset+count);
             const after = [];
             before.forEach((elt, index) => after[index] = fn(elt));
             return this.splice(offset, before, after);
         }
+
+        isArrayLike() { return true; }
+        isStringLike() { return false; }
     }
 }

--- a/test/null_test.js
+++ b/test/null_test.js
@@ -1,0 +1,71 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+'use strict';
+
+import {CreateNull} from '../lib/null.js';
+import {CreateArrayLike} from '../lib/array_like.js';
+
+describe('Null tests', () => {
+    const services = {};
+    services.ArrayLike = CreateArrayLike(services);
+    services.Null = CreateNull(services);
+
+    it ('basics', () => {
+        const n = new services.Null();
+        const converted = JSON.stringify({'hello': n});
+        if (converted !== "{}") {
+            throw new Error("Null converts unpexected to: " + converted);
+        }
+
+        if (n.count() !== 0) {
+            throw new Error("Null count = " + n.count());
+        }
+
+        if (n.slice(0, 0) !== n) {
+            throw new Error("Null slice returns something else");
+        }
+
+        const cb = () => { throw new Error("Unexpected"); };
+        if (n.rangeApply(0, 0, cb) !== n) {
+            throw new Error("Null range apply unexpected returns something else");
+        }
+    });
+
+    it ('throws for invalid params', () => {
+        const n = new services.Null();
+
+        shouldThrow('invalid slice start', () => n.slice(5,5));
+        shouldThrow('invalid slice end', () => n.slice(0, -1));
+        shouldThrow('invalid rangeApply start', () => n.slice(5, 5, noop));
+        shouldThrow('invalid rangeApply count', () => n.slice(0, 1, noop));
+        shouldThrow('invalid rangeApply count2', () => n.slice(0, -1, noop));
+        shouldThrow('invalid splice offset', () => n.splice(5, "", ""));
+        shouldThrow('invalid splice before', () => n.splice(0, "hello", ""));
+        
+        function noop(){}
+        function shouldThrow(msg, cb) {
+            try {
+                cb();
+            } catch (e) {
+                return;
+            }
+            throw new Error("expected to throw but didnt: " + msg);
+        }
+    });
+
+    it ('splices', () => {
+        const n = new services.Null();
+        const afters = [null, "hello", [1]];
+        const befores = [null, "", [], JSON.stringify(n)];
+
+        for (let kk = 0; kk < befores.length; kk ++) {
+            for (let jj = 0; jj < afters.length; jj ++) {
+                if (n.splice(0, befores[kk], afters[jj]) !== afters[jj]) {
+                    throw new Error("splice before/after failed: " + [befores[kk], afters[jj]]);
+                }
+            }
+        }
+    });
+});

--- a/test/sparse_array_test.js
+++ b/test/sparse_array_test.js
@@ -57,7 +57,7 @@ describe('SparseArray tests', () => {
 
     it ('creates slices', () => {
         const input = new services.SparseArray(make([2, 1, 3, "hello"]));
-        let actual = input.slice(1, 3);
+        let actual = input.slice(1, 4);
         let expected = new services.SparseArray(make([1, 1, 2, "hello"]));
 
         if (JSON.stringify(expected) != JSON.stringify(actual)) {
@@ -71,14 +71,14 @@ describe('SparseArray tests', () => {
             throw new Error("Mismatched: " + JSON.stringify(actual));
         }
 
-        actual = input.slice(2, 0);
+        actual = input.slice(2, 2);
         expected = new services.SparseArray(make([]));
 
         if (JSON.stringify(expected) != JSON.stringify(actual)) {
             throw new Error("Mismatched: " + JSON.stringify(actual));
         }
 
-        actual = input.slice(2, 3);
+        actual = input.slice(2, 5);
         expected = new services.SparseArray(make([3, "hello"]));
         
         if (JSON.stringify(expected) != JSON.stringify(actual)) {
@@ -88,7 +88,7 @@ describe('SparseArray tests', () => {
 
     it ('splices - deletes', () => {
         const input = new services.SparseArray(make([2, 1, 4, "hello"]));
-        const left = input.slice(0, 3), right = input.slice(3, 3);
+        const left = input.slice(0, 3), right = input.slice(3, 6);
         const altLeft = input.splice(3, right), altRight = input.splice(0, left);
 
         if (JSON.stringify(left) != JSON.stringify(altLeft)) {
@@ -108,7 +108,7 @@ describe('SparseArray tests', () => {
 
     it ('splices - inserts', () => {
         const input = new services.SparseArray(make([2, 1, 4, "hello"]));
-        const left = input.slice(0, 3), right = input.slice(3, 3);
+        const left = input.slice(0, 3), right = input.slice(3, 6);
 
         const alt1 = left.splice(3, null, right);
         const alt2 = right.splice(0, [], [1, 1, "hello"]);
@@ -145,10 +145,10 @@ describe('SparseArray tests', () => {
     it ('invalid slices', () => {
         const input = new services.SparseArray(make([2, 1]));
         
-        shouldThrow("negative offset", () => input.slice(-1, 0));
+        shouldThrow("negative offset", () => input.slice(-1, -1));
         shouldThrow("negative index", () => input.slice(0, -1));
-        shouldThrow("overflow count", () => input.slice(1, 2));
-        shouldThrow("overflow offset", () => input.slice(3, 0));        
+        shouldThrow("overflow count", () => input.slice(1, 3));
+        shouldThrow("overflow offset", () => input.slice(3, 3));        
     });
 
     it ('invalid splices', () => {


### PR DESCRIPTION
slice is no longer `slice(offset,count)` but more like the standard JS `slice(start,end)`.  Will need to update ModelText but plan to migrate ModelText to `lib` with a standard `String16` implementation.

`splice()` remains as `splice(offset, before, after)` -- mulling move this over to JS semantics as well (but retaining the change data structure as it is for interop reasons).

Also added a null object which will make code simpler.

