### PR TITLE
streams: add initial version

### DIFF
--- a/streams/index.js
+++ b/streams/index.js
@@ -4,5 +4,6 @@
 
 "use strict";
 
-export * from "./core";
-export * from "./streams";
+export * from "./stream.js";
+export * from "./value.js";
+export * from "./string.js";

--- a/streams/stream.js
+++ b/streams/stream.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+export class Stream {
+  constructor() {
+    this.nextChange = null;
+    this.nextInstance = null;
+  }
+
+  append(c) {
+    return this._appendChange(c, false);
+  }
+
+  reverseAppend(c) {
+    return this._appendChange(c, false);
+  }
+
+  _appendChange(c, reverse) {
+    const result = new Stream();
+    let next = result;
+    let s = this;
+    while (s.nextInstance !== null) {
+      [c, next.nextChange] = this._merge(s.nextChange, c, reverse);
+      s = s.nextInstance;
+      next.nextInstance = new Stream();
+      next = next.nextInstance;
+    }
+    [s.nextChange, s.nextInstance] = [c, next];
+    return result;
+  }
+
+  _merge(left, right, reverse) {
+    if (left === null || right === null) {
+      return [right, left];
+    }
+
+    if (!reverse) {
+      return left.merge(right);
+    }
+
+    [right, left] = right.merge(left);
+    return [left, right];
+  }
+}

--- a/streams/string.js
+++ b/streams/string.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { Stream } from "./stream.js";
+import { ValueStream } from "./value.js";
+import { Replace, Atomic } from "../core";
+
+export class StringStream extends ValueStream {
+  constructor(value, stream) {
+    if (typeof value != "string") {
+      throw "value must be string";
+    }
+    super(value, stream);
+  }
+
+  replace(value) {
+    if (typeof value != "string") {
+      throw "replacement must be a string";
+    }
+    return super.append(new Replace(new Atomic(this.value), new Atomic(value)));
+  }
+
+  static toValue(val) {
+    return new Atomic(val);
+  }
+
+  static create(val, stream) {
+    if (typeof val === "string") {
+      return new StringStream(val, stream);
+    }
+    if (val instanceof Atomic) {
+      return this.create(val.value, stream);
+    }
+    throw new "unexpected value type: "() + val.constructor.name;
+  }
+}

--- a/streams/value.js
+++ b/streams/value.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { Stream } from "./stream.js";
+
+export class ValueStream {
+  constructor(value, stream) {
+    this.value = value;
+    this.stream = stream || new Stream();
+  }
+
+  append(c) {
+    const val = this.constructor.toValue(this.value);
+    const applied = val.apply(c);
+    return this.constructor.create(applied, this.stream.append(c));
+  }
+
+  get next() {
+    const next = this.stream.nextInstance;
+    if (next == null) {
+      return null;
+    }
+
+    const val = this.constructor.toValue(this.value);
+    const applied = val.apply(this.stream.nextChange);
+    return this.constructor.create(applied, this.stream.nextInstance);
+  }
+
+  [Symbol.iterator]() {
+    let value = this;
+    return {
+      next() {
+        if (value !== null) {
+          value = value.next;
+        }
+        return value === null ? { done: true } : { value };
+      }
+    };
+  }
+
+  latest() {
+    let result = this;
+    for (let next of this) {
+      result = next;
+    }
+    return result;
+  }
+
+  static toValue(val) {
+    return val;
+  }
+
+  static create(val, stream) {
+    return new ValueStream(val, stream);
+  }
+}

--- a/test/streams/string_test.js
+++ b/test/streams/string_test.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { expect } from "chai";
+
+import { StringStream } from "../..";
+
+describe("String", () => {
+  it("should replace", () => {
+    const s0 = new StringStream("hello");
+    const s1 = s0.replace("world");
+    expect(s1.value).to.equal("world");
+    expect(s0.value).to.equal("hello");
+  });
+
+  it("should converge", () => {
+    const s0 = new StringStream("hello");
+    const s1 = s0.replace("world");
+    expect(s1.value).to.equal("world");
+    expect(s0.value).to.equal("hello");
+    expect(s0.next.value).to.equal("world");
+
+    expect(s1.next).to.equal(null);
+    expect(s0.next.next).to.equal(null);
+  });
+
+  it("should converge with multiple edits", () => {
+    const s0 = new StringStream("hello");
+    const s1 = s0.replace("world");
+    const s2 = s0.replace("froyo");
+    const s3 = s1.replace("fever");
+    const s4 = s2.replace("hoity");
+
+    for (let s of [s0, s1, s2, s3, s4]) {
+      expect(s.latest().value).to.equal("hoity");
+    }
+  });
+});


### PR DESCRIPTION
The example StringStream illustrates basic usage.  Need strongly typed Int  and Float values for use in other constructs.

No branching/merging support (until after ops + demo is done).