### PR TITLE
Replace nextInstance, nextChange with next: {change, version}

### DIFF
--- a/convergent.md
+++ b/convergent.md
@@ -1,0 +1,158 @@
+# Convergent streams in Dot.js
+
+Much of the API surface in Dot.js is exposed via the idea of
+convergent streams. Convergent streams allow implementing a
+distributed convergent system in an almost pure function and reactive
+way.
+
+## Stream definition
+
+A stream captures the idea of a value that changes with time and so it
+exposes a `next` property which should have the shape `{change,
+version}`.
+
+```js
+
+class MinimalStreamImplementation {
+  get next() {
+    const change = this._change;
+    const version = this._version;
+    return {change, version};
+  }
+}
+```
+
+A stream instance always tracks a future version. This allows for
+garbage collection to proceed naturally.  Holding onto previous
+versions will force all older versions to reside in memory even if
+they are not used and effectively be like a leak.
+
+## Value stream vs change streams
+
+The `dotjs.Stream` class implements a simple **change stream** which
+does not have an associated value and only tracks the change
+itself. But it is also possible to track the value as illustrated in
+the
+[dotjs.StringStream](https://github.com/dotchain/dotjs/blob/master/streams/string.js)
+class.
+
+All value streams expose the **current** value via the `value`
+property (which can be an actual dynamic property if lazy calculations
+are involved).
+
+## Mutation and convergence
+
+Stream instances are *almost* **immutable**. Mutation methods (such as
+`StringStream.replace`) return a new stream instance.
+
+The original is almost unchanged: if it didn't have a next field, its
+`next` property will now reflect the current change.  If it does have
+a change, the `next` property itself is not modified.  Instead the
+`next` chain is walked until the end and the change is tacked on
+there.
+
+The change that gets tacked on may not be the original change
+though as it has to account for all the existing `next` values. This
+is done through OT and is the heart of the package but for the
+purposes of this dicussion, the essential guarantee is that both the
+old and the new instance retain their expected values but chasing the
+`next` pointers effectively will cause both to have the same value:
+
+```js
+
+const initial = new dotjs.StringStream("heya");
+
+const first = initial.replace("howdy");
+const second = initial.replace("boo");
+
+// now all three should have converged:
+expect(initial.latest().value).to.equal(first.latest().value);
+expect(initial.latest().value).to.equal(second.latest().value);
+
+```
+
+## Network streams
+
+The network synchronization (via
+[dotjs.Session](https://github.com/dotchain/dotjs/blob/master/session/session.js))
+works on top of streams with the ability to `push()` local
+changes on the stream up to the network and `pull()` remote changes
+from the network to the stream.
+
+## Composition: derived streams
+
+The reactive part of using streams is the ability to compose streams:
+
+```js
+
+function combine(s1, s2, mergeFn) {
+  return {
+     value:  mergeFn(s1.value, s2.value),
+     get next() {
+        if (s1.next !== null) {
+          return combine(s1.next.version, s2, mergeFn);
+        }
+        if (s2.next !== null) {
+          return combine(s1, s2.next.version, mergeFn);
+        }
+        return null;
+     }
+  }
+}
+```
+
+The above example combines streams in a reactive way, always applying
+the `mergeFn` with any change. This is ineffecient in some cases where
+one can do better by looking at the change itself.  For example, if
+one were only filtering for some keys in a map, we can ignore changes
+that affect other keys:
+
+```js
+
+function withKeys(s1, validKeys) {
+  return withKeysValue(s1, _.pick(s1.value, validKeys), validKeys);
+}
+
+function withKeysValue(s1, value, validKeys) {
+   return {
+      value,
+      get next() {
+         if (s1.next == null) {
+            return null;
+         }
+         const c = s1.next.change;
+         if (c instanceof PathChange) {
+            if (c.path !== null && !_.includes(validKeys, c.path[0])) {
+               // not relevant path
+               return withKeysValue(s1.next.version, value, validKey);
+            }
+         }
+         // default: recalculate
+         return withKeys(s1.next.version, validKeys);
+      }
+   }
+}
+```
+
+Note: the example above is just an illustration.  The performance
+impact of redoing the calculation is generally not much and so most
+composition can simply be fully reactive.
+
+## Derived streams and mutability
+
+Most of the base streams provide update methods -- at the very minimum
+the ability to replace the value with another.  In a lot of cases,
+derived streams also have meaningful mutation capabilities.  For
+example, even with a filtered stream, it make sense to support appends
+or additions.
+
+Consider an example of a stream representing an object of two fields A
+and B. The sub-stream for B can be derived from that of the root
+object and effectively should support all mutations that B itself
+provides.
+
+The
+[dotjs.Substream](https://github.com/dotchain/dotjs/blob/master/streams/substream.js)
+function is a useful helper that maps changes back forth. This works
+on change streams though, so the value methods would still need to be
+wrapped up.

--- a/session/conn.js
+++ b/session/conn.js
@@ -27,7 +27,7 @@ export class Conn {
     const headers = { "Content-Type": " application/x-sjson" };
     const body = JSON.stringify(Encoder.encode(req));
 
-    const res = await fetch(url, {method: "POST", body, headers});
+    const res = await fetch(url, { method: "POST", body, headers });
     if (!res.ok) {
       return Promise.reject(res.status + " " + res.statusText);
     }

--- a/session/session.js
+++ b/session/session.js
@@ -93,12 +93,12 @@ export class Session {
   push(conn) {
     // push client side changes
     let s = this._stream;
-    for (let next = s.nextInstance; next != null; next = next.nextInstance) {
+    for (let next = s.next; next != null; next = next.version.next) {
       const pid = this._parentId();
-      const op = new Operation(null, pid, -1, this._version, s.nextChange);
+      const op = new Operation(null, pid, -1, this._version, next.change);
       this._unsent.push(op);
       this._unacked.push(op);
-      s = next;
+      s = next.version;
     }
     this._stream = s;
 

--- a/streams/stream.js
+++ b/streams/stream.js
@@ -6,8 +6,7 @@
 
 export class Stream {
   constructor() {
-    this.nextChange = null;
-    this.nextInstance = null;
+    this.next = null;
   }
 
   append(c) {
@@ -20,15 +19,17 @@ export class Stream {
 
   _appendChange(c, reverse) {
     const result = new Stream();
-    let next = result;
     let s = this;
-    while (s.nextInstance !== null) {
-      [c, next.nextChange] = this._merge(s.nextChange, c, reverse);
-      s = s.nextInstance;
-      next.nextInstance = new Stream();
-      next = next.nextInstance;
+    let nexts = result;
+    while (s.next !== null) {
+      let { change, version } = s.next;
+      s = version;
+
+      [c, change] = this._merge(change, c, reverse);
+      nexts.next = { change, version: new Stream() };
+      nexts = nexts.next.version;
     }
-    [s.nextChange, s.nextInstance] = [c, next];
+    s.next = { change: c, version: nexts };
     return result;
   }
 

--- a/streams/value.js
+++ b/streams/value.js
@@ -19,24 +19,24 @@ export class ValueStream {
   }
 
   get next() {
-    const next = this.stream.nextInstance;
-    if (next == null) {
+    if (this.stream.next === null) {
       return null;
     }
 
+    const { change, version } = this.stream.next;
     const val = this.constructor.toValue(this.value);
-    const applied = val.apply(this.stream.nextChange);
-    return this.constructor.create(applied, this.stream.nextInstance);
+    const applied = val.apply(change);
+    return { change, version: this.constructor.create(applied, version) };
   }
 
   [Symbol.iterator]() {
-    let value = this;
+    let next = { version: this };
     return {
       next() {
-        if (value !== null) {
-          value = value.next;
+        if (next !== null) {
+          next = next.version.next;
         }
-        return value === null ? { done: true } : { value };
+        return next === null ? { done: true } : { value: next.version };
       }
     };
   }

--- a/test/session/sesssion_test.js
+++ b/test/session/sesssion_test.js
@@ -93,8 +93,8 @@ describe("Session", () => {
         });
       })
       .then(() => {
-        expect(str.nextInstance).to.not.equal(null);
-        expect(str.nextChange).to.equal(null);
+        expect(str.next).to.not.equal(null);
+        expect(str.next.change).to.equal(null);
         return s.push({
           write(ops) {
             written = ops;

--- a/test/streams/map_test.js
+++ b/test/streams/map_test.js
@@ -37,10 +37,10 @@ describe("MapStream", () => {
     const m1 = m0.replace(new Map([[1, one]]));
     expect(m1.value).to.deep.equal(new Map([[1, one]]));
     expect(m0.value).to.deep.equal(new Map([[0, zero]]));
-    expect(m0.next.value).to.deep.equal(new Map([[1, one]]));
+    expect(m0.next.version.value).to.deep.equal(new Map([[1, one]]));
 
     expect(m1.next).to.equal(null);
-    expect(m0.next.next).to.equal(null);
+    expect(m0.next.version.next).to.equal(null);
   });
 
   it("should converge with multiple edits", () => {

--- a/test/streams/string_test.js
+++ b/test/streams/string_test.js
@@ -21,10 +21,10 @@ describe("String", () => {
     const s1 = s0.replace("world");
     expect(s1.value).to.equal("world");
     expect(s0.value).to.equal("hello");
-    expect(s0.next.value).to.equal("world");
+    expect(s0.next.version.value).to.equal("world");
 
     expect(s1.next).to.equal(null);
-    expect(s0.next.next).to.equal(null);
+    expect(s0.next.version.next).to.equal(null);
   });
 
   it("should converge with multiple edits", () => {


### PR DESCRIPTION
It still has a bit of stuttering (`next.version.next`), but this is better than the `nextChange`, `nextInstance` business...