### PR TITLE
core: add StructBase and StructDef for custom struct values

### DIFF
--- a/core/map.js
+++ b/core/map.js
@@ -14,7 +14,7 @@ import { ImmutableMap } from "./immutable.js";
 
 // applyMap implements apply() for map-like objects which have
 // get and set methods
-export function applyMap(obj, c) {
+function applyMap(obj, c) {
   if (c == null) {
     return obj;
   }

--- a/core/null.js
+++ b/core/null.js
@@ -12,6 +12,7 @@ export class Null {
     if (!c) {
       return this;
     }
+
     if (c instanceof Replace && c.isCreate()) {
       return c.after;
     }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,16 +28,14 @@ module.exports = function(config) {
     { pattern: "index.js", type: "module" },
     { pattern: "core/**/*.js", type: "module" },
     { pattern: "streams/**/*.js", type: "module" },
-    { pattern: "session/**/*.js", type: "module" }
-  ];
-
-  modules = modules.concat([
+    { pattern: "session/**/*.js", type: "module" },
+    { pattern: "types/**/*.js", type: "module" },
     { pattern: "test/core/testdata/*.js", type: "module" },
     { pattern: "test/core/*.js", type: "module" },
     { pattern: "test/streams/*.js", type: "module" },
     { pattern: "test/session/testdata/*.js", type: "module" },
     { pattern: "test/session/*.js", type: "module" }
-  ]);
+  ];
 
   if (config.e2e) {
     require("esm")(module)("./test/e2e/server.js");

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -88,4 +88,3 @@ class InMemConn {
 }
 
 main();
-

--- a/test/types/.#struct_test.js
+++ b/test/types/.#struct_test.js
@@ -1,0 +1,1 @@
+vkvk@Rameshs-MacBook-Pro.local.1012

--- a/test/types/struct_test.js
+++ b/test/types/struct_test.js
@@ -1,0 +1,81 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { expect } from "chai";
+
+import { Decoder, Replace, Atomic, PathChange } from "../../index.js";
+
+import {
+  StructDef,
+  StructBase,
+  Bool,
+  Int,
+  String,
+  AnyType
+} from "../../types/index.js";
+
+let taskDef = null;
+class Task extends StructBase {
+  constructor(done, str, mint, any) {
+    super();
+    this.done = done;
+    this.str = str;
+    this.mutableInt = mint;
+    this.any = any || null;
+  }
+
+  static structDef() {
+    return taskDef;
+  }
+}
+
+taskDef = new StructDef("task", Task)
+  .withField("done", "Done", Bool)
+  .withField("str", "String", String)
+  .withField("mutableInt", "MutableInt", Int)
+  .withField("any", "Any", AnyType);
+
+Decoder.registerValueClass(Task);
+
+describe("StructDef", () => {
+  it("should ignore empty changes", () => {
+    let n = new Task();
+    expect(n.apply()).to.equal(n);
+  });
+
+  it("should succeed with simple replace", () => {
+    const before = new Task();
+    const repl = new Replace(before, new Atomic(5));
+    expect(before.apply(repl)).to.equal(repl.after);
+  });
+
+  it("should succeed with replacing values", () => {
+    const before = new Task(true, "s", 22, "boo");
+    const replace = new Replace(new Atomic(22), new Atomic(25));
+    const after = before.apply(new PathChange(["MutableInt"], replace));
+    const expected = new Task(true, "s", 25, "boo");
+    expect(after).to.deep.equal(expected);
+  });
+});
+
+describe("Struct - interop serialization", () => {
+  it("should serialize", () => {
+    expect(JSON.stringify(new Task(true, "s"))).to.equal('[true,"s",0,null]');
+    expect(JSON.stringify(new Task(true, "s", 5, "boo"))).to.equal(
+      '[true,"s",5,{"string":"boo"}]'
+    );
+  });
+
+  it("should deserialize", () => {
+    const d = new Decoder();
+
+    let v = d.decodeValue({ task: [true, "s", 5, null] });
+    expect(v).to.deep.equal(new Task(true, "s", 5));
+
+    v = d.decodeValue({ task: [true, "s", 5, { string: "boo" }] });
+    expect(v).to.deep.equal(new Task(true, "s", 5, "boo"));
+  });
+});

--- a/types/index.js
+++ b/types/index.js
@@ -1,0 +1,7 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+export * from "./struct.js";

--- a/types/struct.js
+++ b/types/struct.js
@@ -1,0 +1,193 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { Atomic, Null, Encoder, Replace, PathChange } from "../core/index.js";
+
+// StructBase can be used to simplify creating structs
+export class StructBase {
+  toJSON() {
+    return this.constructor.structDef().toJSON(this);
+  }
+
+  apply(c) {
+    return this.constructor.structDef().apply(this, c);
+  }
+
+  static typeName() {
+    return this.structDef().typeName;
+  }
+
+  static fromJSON(decoder, json) {
+    return this.structDef().fromJSON(decoder, json);
+  }
+}
+
+export class StructDef {
+  constructor(typeName, ctor) {
+    this.typeName = typeName;
+    this._ctor = ctor;
+    this._fields = [];
+  }
+
+  withField(propName, serializationName, propCtor) {
+    this._fields.push(new Field(propName, serializationName, propCtor));
+    return this;
+  }
+
+  apply(obj, c) {
+    if (!c) {
+      return obj;
+    }
+
+    if (c instanceof Replace) {
+      return c.after;
+    }
+
+    if (c instanceof PathChange) {
+      if (c.path === null || c.path.length === 0) {
+        return this.apply(obj, c.change);
+      }
+      const inner = new PathChange(c.path.slice(1), c.change);
+      return this._applyField(obj, c.path[0], inner);
+    }
+
+    return c.applyTo(obj);
+  }
+
+  _applyField(obj, fieldName, change) {
+    const fields = [];
+    for (let field of this._fields) {
+      if (field.is(fieldName)) {
+        fields.push(field.apply(obj, change));
+      } else {
+        fields.push(field.get(obj));
+      }
+    }
+    return new this._ctor(...fields);
+  }
+
+  toJSON(obj) {
+    const result = [];
+    for (let field of this._fields) {
+      result.push(field.toJSON(obj));
+    }
+    return result;
+  }
+
+  fromJSON(decoder, json) {
+    const fields = [];
+    for (let idx = 0; idx < this._fields.length; idx++) {
+      fields.push(this._fields[idx].fromJSON(decoder, json[idx]));
+    }
+    return new this._ctor(...fields);
+  }
+}
+
+class Field {
+  constructor(propName, fieldName, ctor) {
+    this._propName = propName;
+    this._fieldName = fieldName;
+    this._ctor = ctor;
+  }
+
+  is(fieldName) {
+    return this._fieldName === fieldName;
+  }
+
+  get(obj) {
+    return obj[this._propName];
+  }
+
+  apply(obj, c) {
+    if (c instanceof PathChange && (c.path === null || c.path.length === 0)) {
+      c = c.change;
+    }
+
+    const prop = obj[this._propName];
+    if (this._ctor === null || this._ctor.prototype.apply) {
+      return prop.apply(c);
+    }
+
+    const nil = prop === undefined || prop === null;
+    const v = nil ? new Null() : new Atomic(prop);
+    const applied = v.apply(c);
+    return applied instanceof Atomic ? applied.value : null;
+  }
+
+  toJSON(obj) {
+    const prop = obj[this._propName];
+    if (this._ctor === null) {
+      return Encoder.encode(prop);
+    }
+
+    if (prop && prop.toJSON) {
+      return prop.toJSON();
+    }
+
+    if (this._ctor.toJSON) {
+      return this._ctor.toJSON(prop);
+    }
+    return prop;
+  }
+
+  fromJSON(decoder, json) {
+    if (this._ctor === null) {
+      return decoder.decode(json);
+    }
+
+    return this._ctor.fromJSON(decoder, json);
+  }
+}
+
+export const Bool = nativeType("bool", "Bool");
+export const Int = nativeType("int", "Int");
+export const String = nativeType("string", "String");
+export const Date = nativeType("time.Time", "Time");
+export const Float = nativeType("float64", "Float");
+export const AnyType = null;
+
+function nativeType(typeName, displayName) {
+  let toJSON = v => v;
+  let fromJSON = (decoder, json) => decoder.decode({ [typeName]: json });
+
+  switch (typeName) {
+    case "bool":
+      toJSON = v => (Boolean(v) ? true : false);
+      break;
+    case "int":
+      toJSON = v => (Number.isSafeInteger(+v) ? +v : 0);
+      break;
+    case "string":
+      toJSON = v => (v || "").toString();
+      break;
+    case "time.Time":
+      toJSON = v => Encoder.encode(v)["time.Time"];
+      break;
+    case "float64":
+      toJSON = v => (isNaN(+v) ? 0 : +v).toString();
+      break;
+  }
+
+  const t = class {
+    constructor(v) {
+      this.native = v;
+    }
+
+    toJSON() {
+      return toJSON(this.native);
+    }
+
+    static toJSON(obj) {
+      return toJSON(obj);
+    }
+    static fromJSON(decoder, json) {
+      return fromJSON(decoder, json);
+    }
+  };
+
+  const typed = { [displayName]: t };
+  return typed[displayName];
+}


### PR DESCRIPTION
Custom struct value can be added like so:

```js
import {StructBase, StructDef, Int} from "dotjs/types/index.js";
class MyStruct extends StructBase {
    constructor(field1, ....) {
      ...
    }
    static structDef() {
      return new StructDef("golang_struct_name", MyStruct)
        .withField("field1", Int);
    }
}
```