### PR TITLE
dotdb: improve perf of value.next()

### DIFF
--- a/db/stream.js
+++ b/db/stream.js
@@ -99,13 +99,11 @@ export class Stream {
   }
 }
 
-const noCache = {};
-
 /** DerivedStream is a base class for all derived streams */
 export class DerivedStream {
   constructor(parent) {
     this.parent = parent;
-    this._next = noCache;
+    this._next = null;
   }
 
   append(c) {
@@ -137,7 +135,7 @@ export class DerivedStream {
   }
 
   get next() {
-    if (this._next !== noCache) {
+    if (this._next) {
       return this._next;
     }
 

--- a/test/db/map_test.js
+++ b/test/db/map_test.js
@@ -69,7 +69,7 @@ describe("Map dict", () => {
       result[key] = +val;
     }
     expect(result).to.deep.equal({ hello: 100, world: 2 });
-    expect(fn.count.n).to.equal(4);
+    expect(fn.count.n).to.equal(3);
   });
 
   it("should keep up with map additions", () => {
@@ -91,7 +91,7 @@ describe("Map dict", () => {
     expect(result).to.deep.equal({ hello: 1, world: 2, boo: 10 });
     expect(future).instanceOf(Null);
     expect(+future.latest()).to.equal(10);
-    expect(fn.count.n).to.equal(5);
+    expect(fn.count.n).to.equal(3);
   });
 
   it("should keep up with map deletions", () => {
@@ -112,7 +112,7 @@ describe("Map dict", () => {
 
     expect(result).to.deep.equal({ world: 2 });
     expect(hello.latest()).instanceOf(Null);
-    expect(fn.count.n).to.equal(3);
+    expect(fn.count.n).to.equal(2);
   });
 
   it("should proxy changes on mapped values", () => {


### PR DESCRIPTION
The main change is to skip over <nil> change values. These happen quite a bit in derived streams where the underlying change does not affect a derived value.  Without the optimization, this will cause a ripple of nil-change through all cascading derivations.  This reduces that cost significantly without sacrificing the underlying semantics much.

There *is* a lowering of semantics: consider derivation A & B on top of X with two changes c1 and c2.  If c1 is mapped to nil on A but not on B, `A.next` would reflect c2 while `B.next` will only reflect c1.  This can cause issues under some circumstances but all those circumstances seem like bad design choices. 