### PR TITLE
dotdb: add extend() support

### DIFF
--- a/db/extend.js
+++ b/db/extend.js
@@ -1,0 +1,280 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { Changes } from "./changes.js";
+import { Replace } from "./replace.js";
+import { PathChange } from "./path_change.js";
+import { DerivedStream } from "./stream.js";
+import { Null } from "./null.js";
+import { Dict } from "./dict.js";
+import { MapIterator, isMapLike } from "./iterators.js";
+
+/** extend creates an object which has all the keys of both args */
+
+export function extend(store, obj1, obj2) {
+  return new ExtendStream(obj1, obj2).value;
+}
+
+class ExtendStream extends DerivedStream {
+  constructor(obj1, obj2) {
+    super(obj1.stream);
+    this.obj1 = obj1;
+    this.obj2 = obj2;
+  }
+
+  append(c) {
+    return this._append(c, false);
+  }
+
+  reverseAppend(c) {
+    return this._append(c, true);
+  }
+
+  _append(c, reverse) {
+    const c1 = [];
+    const c2 = [];
+
+    this._proxyChange(c, c1, c2, {});
+    if (c1.length + c2.length === 0) {
+      return this;
+    }
+
+    const append = (s, c) => s && (reverse ? s.reverseAppend(c) : s.append(c));
+    const s1 = append(this.obj1.stream, Changes.create(c1));
+    const s2 = append(this.obj2.stream, Changes.create(c2));
+    const obj1 = this.obj1
+      .apply(Changes.create(c1))
+      .clone()
+      .setStream(s1);
+    const obj2 = this.obj2
+      .apply(Changes.create(c2))
+      .clone()
+      .setStream(s2);
+    return new ExtendStream(obj1, obj2);
+  }
+
+  get value() {
+    if (!isMapLike(this.obj1) && !isMapLike(this.obj2)) {
+      return new Null().setStream(this);
+    }
+
+    const result = {};
+    if (isMapLike(this.obj1)) {
+      for (let [key, val] of this.obj1[MapIterator]()) {
+        result[key] = val;
+      }
+    }
+
+    if (isMapLike(this.obj2)) {
+      for (let [key, val] of this.obj2[MapIterator]()) {
+        result[key] = val;
+      }
+    }
+    return new Dict(result).setStream(this);
+  }
+
+  _getNext() {
+    const next1 = this.obj1.next;
+    const next2 = this.obj2.next;
+
+    if (!next1 && !next2) {
+      return null;
+    }
+
+    const obj1 = next1 ? next1.version : this.obj1;
+    const obj2 = next2 ? next2.version : this.obj2;
+    const version = new ExtendStream(obj1, obj2);
+
+    const changes = [];
+    const redo =
+      !isMapLike(this.obj1) ||
+      !isMapLike(this.obj2) ||
+      !isMapLike(obj1) ||
+      !isMapLike(obj2) ||
+      this._filterNext1(next1 && next1.change, changes) ||
+      this._filterNext2(next2 && next2.change, obj1, changes);
+
+    if (redo) {
+      const change = new Replace(this.value.clone(), version.value.clone());
+      return { change, version };
+    }
+
+    return { change: Changes.create(changes), version };
+  }
+
+  _filterNext1(c, changes) {
+    if (!c) {
+      return false;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._filterNext1(cx, changes)) return true;
+      }
+      return false;
+    }
+
+    if (!(c instanceof PathChange)) {
+      return true;
+    }
+
+    if (!c.path || c.path.length === 0) {
+      return this._filterNext1(c.change, changes);
+    }
+
+    if (!this.obj2.keyExists(c.path[0])) {
+      changes.push(c);
+    }
+
+    return false;
+  }
+
+  _filterNext2(c, obj1, changes) {
+    if (!c) {
+      return false;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._filterNext2(cx, obj1, changes)) return true;
+      }
+      return false;
+    }
+
+    if (!(c instanceof PathChange)) {
+      return true;
+    }
+
+    if (!c.path || c.path.length === 0) {
+      return this._filterNext2(c.change, obj1, changes);
+    }
+
+    if (!obj1.keyExists(c.path[0])) {
+      changes.push(c);
+      return false;
+    }
+
+    const inner = [];
+    const cx = PathChange.create(c.path.slice(1), c.change);
+    if (this._filterOverride(cx, obj1, c.path[0], inner)) {
+      return true;
+    }
+    if (inner.length) {
+      changes.push(PathChange.create([c.path[0]], Changes.create(inner)));
+    }
+
+    return false;
+  }
+
+  _filterOverride(c, obj1, key, changes) {
+    if (!c) {
+      return false;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._filterOverride(cx, obj1, key, changes)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    if (c instanceof Replace) {
+      const before =
+        c.before instanceof Null ? obj1.get(key).clone() : c.before;
+      const after = c.after instanceof Null ? obj1.get(key).clone() : c.after;
+      changes.push(new Replace(before, after));
+      return false;
+    }
+
+    if (c instanceof PathChange) {
+      if (!c.path || c.path.length === 0) {
+        return this._filterOverride(c.change, obj1, key, changes);
+      }
+      changes.push(c);
+      return false;
+    }
+
+    return true;
+  }
+
+  _proxyChange(c, c1, c2, removed) {
+    if (!c) {
+      return;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        this._proxyChange(cx, c1, c2, removed);
+      }
+    }
+
+    if (!(c instanceof PathChange)) {
+      throw new Error("cannot proxy change");
+    }
+
+    if (!c.path || c.path.length === 0) {
+      return this._proxyChange(c.change, c1, c2, removed);
+    }
+
+    const cx = PathChange.create(c.path.slice(1), c.change);
+    return this._proxyKeyChange(c.path[0], cx, c1, c2, removed);
+  }
+
+  _proxyKeyChange(key, inner, c1, c2, removed) {
+    if (!inner) {
+      return;
+    }
+
+    const exists1 =
+      isMapLike(this.obj1) &&
+      this.obj1.keyExists(key) &&
+      !(removed[key] instanceof Null);
+    const exists2 = isMapLike(this.obj2) && this.obj2.keyExists(key);
+
+    if (!exists1) {
+      c2.push(PathChange.create([key], inner));
+      return;
+    }
+
+    const before = removed[key] || this.obj1.get(key).clone();
+
+    if (exists1 && !exists2) {
+      c1.push(PathChange.create([key], inner));
+      removed[key] = before.apply(inner);
+      return;
+    }
+
+    if (this._isDeletion(inner)) {
+      c1.push(PathChange.create([key], new Replace(before, new Null())));
+      removed[key] = new Null();
+    }
+    c2.push(PathChange.create([key], inner));
+  }
+
+  _isDeletion(c) {
+    if (c instanceof Replace) {
+      return c.after instanceof Null;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._isDeletion(cx)) {
+          return true;
+        }
+      }
+    }
+
+    if (c instanceof PathChange) {
+      if (!c.path || c.path.length === 0) {
+        return this._isDeletion(c.change);
+      }
+    }
+
+    return false;
+  }
+}

--- a/db/index.js
+++ b/db/index.js
@@ -22,3 +22,4 @@ export { MapIterator, SeqIterator } from "./iterators.js";
 export { map } from "./map.js";
 export { filter } from "./filter.js";
 export { group } from "./group.js";
+export { extend } from "./extend.js";

--- a/dist/dotdb.js
+++ b/dist/dotdb.js
@@ -1950,6 +1950,273 @@ class Dict extends Value {
 
 Decoder.registerValueClass(Dict);
 
+/** extend creates an object which has all the keys of both args */
+
+function extend(store, obj1, obj2) {
+  return new ExtendStream(obj1, obj2).value;
+}
+
+class ExtendStream extends DerivedStream {
+  constructor(obj1, obj2) {
+    super(obj1.stream);
+    this.obj1 = obj1;
+    this.obj2 = obj2;
+  }
+
+  append(c) {
+    return this._append(c, false);
+  }
+
+  reverseAppend(c) {
+    return this._append(c, true);
+  }
+
+  _append(c, reverse) {
+    const c1 = [];
+    const c2 = [];
+
+    this._proxyChange(c, c1, c2, {});
+    if (c1.length + c2.length === 0) {
+      return this;
+    }
+
+    const append = (s, c) => s && (reverse ? s.reverseAppend(c) : s.append(c));
+    const s1 = append(this.obj1.stream, Changes.create(c1));
+    const s2 = append(this.obj2.stream, Changes.create(c2));
+    const obj1 = this.obj1
+      .apply(Changes.create(c1))
+      .clone()
+      .setStream(s1);
+    const obj2 = this.obj2
+      .apply(Changes.create(c2))
+      .clone()
+      .setStream(s2);
+    return new ExtendStream(obj1, obj2);
+  }
+
+  get value() {
+    if (!isMapLike(this.obj1) && !isMapLike(this.obj2)) {
+      return new Null().setStream(this);
+    }
+
+    const result = {};
+    if (isMapLike(this.obj1)) {
+      for (let [key, val] of this.obj1[MapIterator]()) {
+        result[key] = val;
+      }
+    }
+
+    if (isMapLike(this.obj2)) {
+      for (let [key, val] of this.obj2[MapIterator]()) {
+        result[key] = val;
+      }
+    }
+    return new Dict(result).setStream(this);
+  }
+
+  _getNext() {
+    const next1 = this.obj1.next;
+    const next2 = this.obj2.next;
+
+    if (!next1 && !next2) {
+      return null;
+    }
+
+    const obj1 = next1 ? next1.version : this.obj1;
+    const obj2 = next2 ? next2.version : this.obj2;
+    const version = new ExtendStream(obj1, obj2);
+
+    const changes = [];
+    const redo =
+      !isMapLike(this.obj1) ||
+      !isMapLike(this.obj2) ||
+      !isMapLike(obj1) ||
+      !isMapLike(obj2) ||
+      this._filterNext1(next1 && next1.change, changes) ||
+      this._filterNext2(next2 && next2.change, obj1, changes);
+
+    if (redo) {
+      const change = new Replace(this.value.clone(), version.value.clone());
+      return { change, version };
+    }
+
+    return { change: Changes.create(changes), version };
+  }
+
+  _filterNext1(c, changes) {
+    if (!c) {
+      return false;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._filterNext1(cx, changes)) return true;
+      }
+      return false;
+    }
+
+    if (!(c instanceof PathChange)) {
+      return true;
+    }
+
+    if (!c.path || c.path.length === 0) {
+      return this._filterNext1(c.change, changes);
+    }
+
+    if (!this.obj2.keyExists(c.path[0])) {
+      changes.push(c);
+    }
+
+    return false;
+  }
+
+  _filterNext2(c, obj1, changes) {
+    if (!c) {
+      return false;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._filterNext2(cx, obj1, changes)) return true;
+      }
+      return false;
+    }
+
+    if (!(c instanceof PathChange)) {
+      return true;
+    }
+
+    if (!c.path || c.path.length === 0) {
+      return this._filterNext2(c.change, obj1, changes);
+    }
+
+    if (!obj1.keyExists(c.path[0])) {
+      changes.push(c);
+      return false;
+    }
+
+    const inner = [];
+    const cx = PathChange.create(c.path.slice(1), c.change);
+    if (this._filterOverride(cx, obj1, c.path[0], inner)) {
+      return true;
+    }
+    if (inner.length) {
+      changes.push(PathChange.create([c.path[0]], Changes.create(inner)));
+    }
+
+    return false;
+  }
+
+  _filterOverride(c, obj1, key, changes) {
+    if (!c) {
+      return false;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._filterOverride(cx, obj1, key, changes)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    if (c instanceof Replace) {
+      const before =
+        c.before instanceof Null ? obj1.get(key).clone() : c.before;
+      const after = c.after instanceof Null ? obj1.get(key).clone() : c.after;
+      changes.push(new Replace(before, after));
+      return false;
+    }
+
+    if (c instanceof PathChange) {
+      if (!c.path || c.path.length === 0) {
+        return this._filterOverride(c.change, obj1, key, changes);
+      }
+      changes.push(c);
+      return false;
+    }
+
+    return true;
+  }
+
+  _proxyChange(c, c1, c2, removed) {
+    if (!c) {
+      return;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        this._proxyChange(cx, c1, c2, removed);
+      }
+    }
+
+    if (!(c instanceof PathChange)) {
+      throw new Error("cannot proxy change");
+    }
+
+    if (!c.path || c.path.length === 0) {
+      return this._proxyChange(c.change, c1, c2, removed);
+    }
+
+    const cx = PathChange.create(c.path.slice(1), c.change);
+    return this._proxyKeyChange(c.path[0], cx, c1, c2, removed);
+  }
+
+  _proxyKeyChange(key, inner, c1, c2, removed) {
+    if (!inner) {
+      return;
+    }
+
+    const exists1 =
+      isMapLike(this.obj1) &&
+      this.obj1.keyExists(key) &&
+      !(removed[key] instanceof Null);
+    const exists2 = isMapLike(this.obj2) && this.obj2.keyExists(key);
+
+    if (!exists1) {
+      c2.push(PathChange.create([key], inner));
+      return;
+    }
+
+    const before = removed[key] || this.obj1.get(key).clone();
+
+    if (exists1 && !exists2) {
+      c1.push(PathChange.create([key], inner));
+      removed[key] = before.apply(inner);
+      return;
+    }
+
+    if (this._isDeletion(inner)) {
+      c1.push(PathChange.create([key], new Replace(before, new Null())));
+      removed[key] = new Null();
+    }
+    c2.push(PathChange.create([key], inner));
+  }
+
+  _isDeletion(c) {
+    if (c instanceof Replace) {
+      return c.after instanceof Null;
+    }
+
+    if (c instanceof Changes) {
+      for (let cx of c) {
+        if (this._isDeletion(cx)) {
+          return true;
+        }
+      }
+    }
+
+    if (c instanceof PathChange) {
+      if (!c.path || c.path.length === 0) {
+        return this._isDeletion(c.change);
+      }
+    }
+
+    return false;
+  }
+}
+
 /** Text represents a string value */
 class Text extends Value {
   constructor(text) {
@@ -2652,12 +2919,12 @@ class GroupStream extends DerivedStream {
     if (c instanceof Changes) {
       const changes = [];
       for (let cx of c) {
-        cx = result._proxyChange(cx, groupsMap);
+        cx = this._proxyChange(cx, groupsMap);
         if (cx) {
           changes.push(cx);
         }
       }
-      return Changes.create(result);
+      return Changes.create(changes);
     }
 
     if (!(c instanceof PathChange)) {
@@ -3245,5 +3512,6 @@ module.exports = {
   field,
   map,
   filter,
-  group
+  group,
+  extend
 };

--- a/test/db/benchmark_test.js
+++ b/test/db/benchmark_test.js
@@ -1,0 +1,57 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { Value } from "../../db/value.js";
+
+import {
+  field,
+  group,
+  Num,
+  Dict,
+  Text,
+  Stream,
+  Store
+} from "../../db/index.js";
+
+class One extends Value {
+  constructor(count) {
+    super();
+    this.count = count;
+  }
+
+  clone() {
+    return new One(this.count);
+  }
+
+  invoke(store, args) {
+    this.count.n++;
+    return field(store, field(store, args, new Text("it")), new Text("one"));
+  }
+}
+
+describe.skip("Benchmark", () => {
+  it("group", () => {
+    const m = {};
+    for (let kk = 0; kk < 10000; kk++) {
+      m[kk] = new Dict({ one: new Num(kk % 2) });
+    }
+
+    for (let kk = 0; kk < 10; kk++) {
+      const initial = new Dict(m).setStream(new Stream());
+      const fn = new One({ n: 0 });
+      const grouped = group(new Store(), initial, fn);
+      initial
+        .get("5")
+        .get("one")
+        .replace(new Num(5));
+      initial
+        .get("6")
+        .get("one")
+        .replace(new Num(5));
+      grouped.latest();
+    }
+  }).timeout(10000);
+});

--- a/test/db/extend_test.js
+++ b/test/db/extend_test.js
@@ -1,0 +1,288 @@
+// Copyright (C) 2019 rameshvk. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+"use strict";
+
+import { expect } from "chai";
+
+import {
+  extend,
+  Null,
+  Dict,
+  Text,
+  Stream,
+  MapIterator,
+  Store
+} from "../../db/index.js";
+
+describe("extend", () => {
+  it("should extend", () => {
+    const left = new Dict({
+      hello: new Text("hello"),
+      world: new Text("world")
+    });
+    const right = new Dict({
+      hello: new Text("hello2"),
+      boo: new Text("hoo")
+    });
+    const extended = extend(new Store(), left, right);
+
+    const result = {};
+    for (let [key, val] of extended[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello2",
+      world: "world",
+      boo: "hoo"
+    });
+  });
+
+  it("should keep up with changes", () => {
+    const left = new Dict({
+      hello: new Text("hello"),
+      world: new Text("world")
+    }).setStream(new Stream());
+    const right = new Dict({
+      hello: new Text("hello2"),
+      boo: new Text("hoo")
+    }).setStream(new Stream());
+    const extended = extend(new Store(), left, right);
+
+    left.get("left").replace(new Text("left"));
+    left.get("left2").replace(new Text("left2"));
+    left.get("hello").replace(new Text("hell"));
+    left.get("world").replace(new Text("world-left"));
+    right.get("right").replace(new Text("right"));
+    right.get("boo").replace(new Text("hoo2"));
+    right.get("hello").replace(new Null());
+    right.get("left2").replace(new Text("right2"));
+
+    const result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      left: "left",
+      hello: "hell",
+      world: "world-left",
+      right: "right",
+      boo: "hoo2",
+      left2: "right2"
+    });
+  });
+
+  it("should proxy changes to right", () => {
+    const left = new Dict({
+      hello: new Text("hello"),
+      world: new Text("world")
+    }).setStream(new Stream());
+    const right = new Dict({
+      hello: new Text("hello2"),
+      boo: new Text("hoo")
+    }).setStream(new Stream());
+    const extended = extend(new Store(), left, right);
+    extended.get("new").replace(new Text("new3"));
+    extended.get("boo").replace(new Text("boo3"));
+    extended.get("hello").replace(new Text("hello3"));
+
+    const result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello3",
+      world: "world",
+      boo: "boo3",
+      new: "new3"
+    });
+    expect(left.next).to.equal(null);
+  });
+
+  it("should proxy changes to left", () => {
+    const left = new Dict({
+      hello: new Text("hello"),
+      boo: new Text("boo"),
+      world: new Text("world")
+    }).setStream(new Stream());
+    const right = new Dict({
+      hello: new Text("hello2"),
+      hoo: new Text("hoo")
+    }).setStream(new Stream());
+    const extended = extend(new Store(), left, right);
+
+    extended.get("world").replace(new Text("world3"));
+    extended.get("boo").replace(new Null());
+
+    const result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello2",
+      world: "world3",
+      hoo: "hoo"
+    });
+    expect(right.next).to.equal(null);
+  });
+
+  it("should proxy deletions of common keys", () => {
+    const left = new Dict({
+      hello: new Text("hello"),
+      boo: new Text("boo"),
+      world: new Text("world")
+    }).setStream(new Stream());
+    const right = new Dict({
+      hello: new Text("hello2"),
+      hoo: new Text("hoo"),
+      world: new Text("world")
+    }).setStream(new Stream());
+    const extended = extend(new Store(), left, right);
+
+    extended.get("world").replace(new Null());
+    extended.get("hello").replace(new Null());
+    extended
+      .latest()
+      .get("hello")
+      .replace(new Text("oops"));
+
+    const result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "oops",
+      boo: "boo",
+      hoo: "hoo"
+    });
+    expect(
+      left
+        .latest()
+        .get("world")
+        .clone()
+    ).to.deep.equal(new Null());
+    expect(
+      left
+        .latest()
+        .get("hello")
+        .clone()
+    ).to.deep.equal(new Null());
+    expect(
+      right
+        .latest()
+        .get("world")
+        .clone()
+    ).to.deep.equal(new Null());
+    expect(right.latest().get("hello").text).to.deep.equal("oops");
+  });
+
+  it("should work with non-dict left", () => {
+    const left = new Text("boo").setStream(new Stream());
+    const right = new Dict({
+      hello: new Text("hello2"),
+      hoo: new Text("hoo"),
+      world: new Text("world")
+    }).setStream(new Stream());
+    const extended = extend(new Store(), left, right);
+
+    let result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello2",
+      hoo: "hoo",
+      world: "world"
+    });
+
+    left.replace(
+      new Dict({
+        hello: new Text("hello"),
+        boo: new Text("boo")
+      })
+    );
+
+    result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello2",
+      hoo: "hoo",
+      boo: "boo",
+      world: "world"
+    });
+
+    left.replace(new Text("coo"));
+
+    result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello2",
+      hoo: "hoo",
+      world: "world"
+    });
+  });
+
+  it("should work with non-dict right", () => {
+    const left = new Dict({
+      hello: new Text("hello"),
+      boo: new Text("boo")
+    }).setStream(new Stream());
+    const right = new Text("boo").setStream(new Stream());
+    const extended = extend(new Store(), left, right);
+
+    let result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello",
+      boo: "boo"
+    });
+
+    right.replace(
+      new Dict({
+        hello: new Text("hello2"),
+        hoo: new Text("hoo"),
+        world: new Text("world")
+      })
+    );
+
+    result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello2",
+      hoo: "hoo",
+      boo: "boo",
+      world: "world"
+    });
+
+    right.replace(new Text("coo"));
+
+    result = {};
+    for (let [key, val] of extended.latest()[MapIterator]()) {
+      result[key] = val.text;
+    }
+
+    expect(result).to.deep.equal({
+      hello: "hello",
+      boo: "boo"
+    });
+  });
+});

--- a/x/generate_dist.js
+++ b/x/generate_dist.js
@@ -26,7 +26,8 @@ const exported = [
   "field",
   "map",
   "filter",
-  "group"
+  "group",
+  "extend"
 ];
 
 function orderFiles() {


### PR DESCRIPTION
Extend is useful for adding virtual fields to existing objects. When used with map, this can effectively add extra columns (which remain editable to the underlying references!).
