### PR TITLE
db: cleanup append() interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,20 @@ it("proxies edits on filtered dictionaries", () => {
 
   expect(filtered.get("boo")).to.be.instanceOf(Null);
   expect(filtered.get("hello").text).to.equal("world");
+
+  filtered.get("seven").replace(new Text("wonders"));
+
+  // see update reflected on the underlying dictionary
+  expect(initial.latest().get("seven").text).to.equal("wonders");
 });
 ```
 
-The specific implementations of `field`, `map`, `filter`, `group` and other such functions provided by `DotDB` all try to have reasonable behavior for mutating the output and proxying those changes upstream.  For a given definition of the reactive forward data flow, multiple reverse flows can be defined and all the `bi-directional` primitives in `DotDB` pin these behaviors.  Custom behaviors are possible (though intricate to get right at this point) but the inherent strength of two-way bindings is that the usual complexity of event-handling can be avoided with a fairly declarative setup.
+The specific implementations of `field`, `map`, `filter`, `group` and other such functions provided by `DotDB` all try to have reasonable behavior for mutating the output and proxying those changes upstream.  
+
+The `filter` example illustrates one difficult choice with mutations on the output: some mutations either don't make sense (such as modifying the filtered value in ways that violate the filter constraint) or mutations lack a clear meaning (such as when `replace()` is called on the filtered value -- does this replace all the existing elements or the whole underlying input being filtered).
+
+When considering bi-directional transformations, the declarative function should capture both the forward flow and the feedback flow.   t this point in this project, the two flows are meshed together in a single implementation of `filter` but the longer term approach is likely to decouple these and have the definition be an explicit composition of a forward and a feedback flow.
+
 
      One of the goals here is to use DotDB to build UI apps where
      the complexities of event-handling are not used.  Instead, much

--- a/db/branch.js
+++ b/db/branch.js
@@ -17,20 +17,20 @@ import { Stream } from "./stream.js";
  */
 export function branch(s) {
   const child = new Stream();
-  return new Branch({ parent: s, child }, child);
+  return new BranchStream(child, { parent: s, child });
 }
 
-class Branch {
-  constructor(info, underlying) {
-    this._info = info;
-    this._underlying = underlying;
+class BranchStream {
+  constructor(parent, info) {
+    this.parent = parent;
+    this.info = info;
   }
 
   push() {
-    const info = this._info;
-    for (let next = info.child.next; next != null; next = info.child.next) {
+    const info = this.info;
+    for (let next = info.child.next; next; next = info.child.next) {
       const { change, version } = next;
-      info.parent = info.parent.append(change);
+      info.parent = info.parent.append(change).version;
       info.child = version;
     }
 
@@ -38,10 +38,10 @@ class Branch {
   }
 
   pull() {
-    const info = this._info;
+    const info = this.info;
     for (let next = info.parent.next; next != null; next = info.parent.next) {
       const { change, version } = next;
-      info.child = info.child.reverseAppend(change);
+      info.child = info.child.reverseAppend(change).version;
       info.parent = version;
     }
 
@@ -49,25 +49,30 @@ class Branch {
   }
 
   get next() {
-    const n = this._underlying.next;
-    return n === null
-      ? null
-      : { change: n.change, version: new Branch(this._info, n.version) };
+    return this._nextf(this.parent.next);
   }
 
   append(c) {
-    return new Branch(this._info, this._underlying.append(c));
+    return this._nextf(this.parent && this.parent.append(c));
   }
 
   reverseAppend(c) {
-    return new Branch(this._info, this._underlying.reverseAppend(c));
+    return this._nextf(this.parent && this.parent.reverseAppend(c));
+  }
+
+  _nextf(n) {
+    if (!n) {
+      return null;
+    }
+    const version = new BranchStream(n.version, this.info);
+    return { change: n.change, version };
   }
 
   undo() {
-    return this._underlying.undo();
+    return this.parent.undo();
   }
 
   redo() {
-    return this._underlying.redo();
+    return this.parent.redo();
   }
 }

--- a/db/docs/jsdoc.md
+++ b/db/docs/jsdoc.md
@@ -13,9 +13,6 @@
 <dt><a href="#Dict">Dict</a></dt>
 <dd><p>Dict represents a map/hash/dictionary/collection with string keys</p>
 </dd>
-<dt><a href="#Field">Field</a></dt>
-<dd><p>Field is a calculation that when invoked returns obj.field</p>
-</dd>
 <dt><a href="#GroupStream">GroupStream</a></dt>
 <dd><p>GroupStream implements a groupd dict-of-dict-like stream</p>
 </dd>
@@ -288,12 +285,6 @@ check if key exists
 clone makes a copy but with stream set to null
 
 **Kind**: instance method of [<code>Dict</code>](#Dict)  
-<a name="Field"></a>
-
-## Field
-Field is a calculation that when invoked returns obj.field
-
-**Kind**: global class  
 <a name="GroupStream"></a>
 
 ## GroupStream
@@ -748,6 +739,7 @@ well as static fromJSON and optionally override apply().
     * [.next](#Value+next) : <code>Object</code>
     * [.setStream()](#Value+setStream)
     * [.replace()](#Value+replace) ⇒ [<code>Value</code>](#Value)
+    * [.appendChange()](#Value+appendChange)
     * [.latest()](#Value+latest)
     * [.apply()](#Value+apply)
     * [.branch()](#Value+branch)
@@ -775,6 +767,13 @@ replace substitutes this with another value
 
 **Kind**: instance method of [<code>Value</code>](#Value)  
 **Returns**: [<code>Value</code>](#Value) - r - r has same stream as this  
+<a name="Value+appendChange"></a>
+
+### value.appendChange()
+appendChange applies a change to the value and the underlying stream
+It returns a {change, version} tuple much like next does.
+
+**Kind**: instance method of [<code>Value</code>](#Value)  
 <a name="Value+latest"></a>
 
 ### value.latest()

--- a/db/extend.js
+++ b/db/extend.js
@@ -53,7 +53,7 @@ class ExtendStream extends DerivedStream {
       .apply(Changes.create(c2))
       .clone()
       .setStream(s2);
-    return new ExtendStream(obj1, obj2);
+    return { change: c, version: new ExtendStream(obj1, obj2) };
   }
 
   get value() {

--- a/db/group.js
+++ b/db/group.js
@@ -53,14 +53,21 @@ class GroupStream extends DerivedStream {
 
     const groupsMap = Object.assign({}, this.groupsMap);
     c = this._proxyChange(c, groupsMap);
-    const stream = this.base.stream;
-    const updated =
-      stream && reverse ? stream.reverseAppend(c) : stream.append(c);
+    const s = this.base.stream;
+    return this._nextf(reverse ? s.reverseAppend(c) : s.append(c), groupsMap);
+  }
+
+  _nextf(n, groupsMap) {
+    if (!n) {
+      return null;
+    }
+
     const base = this.base
-      .apply(c)
+      .apply(n.change)
       .clone()
-      .setStream(updated);
-    return new GroupStream(base, this.groups, groupsMap);
+      .setStream(n.version);
+    const version = new GroupStream(base, this.groups, groupsMap);
+    return { change: n.change, version };
   }
 
   get value() {

--- a/db/index.js
+++ b/db/index.js
@@ -12,7 +12,7 @@ export { Num } from "./num.js";
 export { Bool } from "./bool.js";
 export { Null } from "./null.js";
 export { Ref } from "./ref.js";
-export { Field, field } from "./field.js";
+export { field } from "./field.js";
 export { View, invoke } from "./view.js";
 export { run } from "./run.js";
 export { Conn } from "./conn.js";

--- a/db/run.js
+++ b/db/run.js
@@ -28,6 +28,23 @@ export class RunStream extends DerivedStream {
     this.obj = obj;
   }
 
+  append(c) {
+    return this._nextf(this.parent && this.parent.append(c));
+  }
+
+  reverseAppend(c) {
+    return this._nextf(this.parent && this.parent.reverseAppend(c));
+  }
+
+  _nextf(n) {
+    if (!n) {
+      return null;
+    }
+    const val = this.value.apply(n.change).setStream(n.version);
+    const version = new RunStream(this.store, this.obj, val);
+    return { change: n.change, version };
+  }
+
   _getNext() {
     const n = this.store.next;
     if (n) {

--- a/db/seq.js
+++ b/db/seq.js
@@ -32,9 +32,7 @@ export class Seq extends Value {
    */
   splice(offset, count, replacement) {
     const before = this.slice(offset, offset + count);
-    const change = new Splice(offset, before, replacement);
-    const version = this.stream && this.stream.append(change);
-    return this._nextf(change, version).version;
+    return this.appendChange(new Splice(offset, before, replacement)).version;
   }
 
   /**
@@ -50,9 +48,7 @@ export class Seq extends Value {
    * @return {Text}
    */
   move(offset, count, distance) {
-    const change = new Move(offset, count, distance);
-    const version = this.stream && this.stream.append(change);
-    return this._nextf(change, version).version;
+    return this.appendChange(new Move(offset, count, distance)).version;
   }
 
   /** clone makes a copy but with stream set to null */

--- a/db/stream.js
+++ b/db/stream.js
@@ -60,13 +60,13 @@ export class Stream {
 
   /* append adds a local change */
   append(c) {
-    return this._appendChange(c, false);
+    return { change: c, version: this._appendChange(c, false) };
   }
 
   /* reverseAppend adds an *upstream* change; meant to be used by nw
    * synchronizers */
   reverseAppend(c) {
-    return this._appendChange(c, true);
+    return { change: c, version: this._appendChange(c, true) };
   }
 
   _appendChange(c, reverse) {
@@ -106,28 +106,28 @@ export class DerivedStream {
     this._next = null;
   }
 
-  append(c) {
-    return this.parent.append(c);
+  append() {
+    return null;
   }
 
-  reverseAppend(c) {
-    return this.parent.reverseAppend(c);
+  reverseAppend() {
+    return null;
   }
 
   push() {
-    return this.parent.push();
+    return this.parent && this.parent.push();
   }
 
   pull() {
-    return this.parent.pull();
+    return this.parent && this.parent.pull();
   }
 
   undo() {
-    return this.parent.undo();
+    return this.parent && this.parent.undo();
   }
 
   redo() {
-    return this.parent.redo();
+    return this.parent && this.parent.redo();
   }
 
   get next() {

--- a/db/substream.js
+++ b/db/substream.js
@@ -19,30 +19,31 @@ export class Substream extends DerivedStream {
   }
 
   append(c) {
-    const p = this.parent && this.parent.append(new PathChange([this.key], c));
-    // TODO: the key have changed!
-    return new Substream(p, this.key);
+    const cx = new PathChange([this.key], c);
+    return this._nextf(this.parent && this.parent.append(cx));
   }
 
   reverseAppend(c) {
-    const p =
-      this.parent && this.parent.reverseAppend(new PathChange([this.key], c));
-    // TODO: the key may have changed!
-    return new Substream(p, this.key);
+    const cx = new PathChange([this.key], c);
+    return this._nextf(this.parent && this.parent.reverseAppend(cx));
+  }
+
+  _nextf(n) {
+    if (!n) {
+      return null;
+    }
+
+    const { xform, key, ok } = transform(n.change, this.key);
+    if (!ok) {
+      // TODO: this should not be null for append case?
+      return null;
+    }
+
+    return { change: xform, version: new Substream(n.version, key) };
   }
 
   _getNext() {
-    const next = this.parent && this.parent.next;
-    if (!next) {
-      return null;
-    }
-
-    const { xform, key, ok } = transform(next.change, this.key);
-    if (!ok) {
-      return null;
-    }
-
-    return { change: xform, version: new Substream(next.version, key) };
+    return this._nextf(this.parent && this.parent.next);
   }
 }
 

--- a/db/test/field_test.js
+++ b/db/test/field_test.js
@@ -6,7 +6,7 @@
 
 import { expect } from "chai";
 
-import { Dict, Ref, Store, Stream, Text, Field, Null } from "../index.js";
+import { field, Dict, Ref, Store, Stream, Text, Null } from "../index.js";
 
 describe("Field", () => {
   function newStore() {
@@ -26,17 +26,13 @@ describe("Field", () => {
     return s.next.version.next.version.next.version;
   }
 
-  it("should invoke", () => {
-    const s = newStore();
-    const fn = new Field();
-    const f = fn.invoke(s, s.get("table1").get("args"));
-    expect(f.text).to.equal("hello");
-  });
-
   it("should track object", () => {
     const s = newStore();
-    const fn = new Field();
-    const f = fn.invoke(s, s.get("table1").get("args"));
+    const f = field(
+      s,
+      new Ref(["table1", "args", "obj"]),
+      new Ref(["table1", "args", "field"])
+    );
     s.get("table1")
       .get("row1")
       .get("col1")
@@ -47,8 +43,11 @@ describe("Field", () => {
 
   it("should track field", () => {
     const s = newStore();
-    const fn = new Field();
-    const f = fn.invoke(s, s.get("table1").get("args"));
+    const f = field(
+      s,
+      new Ref(["table1", "args", "obj"]),
+      new Ref(["table1", "args", "field"])
+    );
     s.get("table1")
       .get("args")
       .get("field")
@@ -59,8 +58,11 @@ describe("Field", () => {
 
   it("should proxy changes", () => {
     const s = newStore();
-    const fn = new Field();
-    const f = fn.invoke(s, s.get("table1").get("args"));
+    const f = field(
+      s,
+      new Ref(["table1", "args", "obj"]),
+      new Ref(["table1", "args", "field"])
+    );
     f.replace(new Text("world"));
 
     expect(

--- a/db/test/view_test.js
+++ b/db/test/view_test.js
@@ -6,17 +6,9 @@
 
 import { expect } from "chai";
 
-import {
-  View,
-  Field,
-  Dict,
-  Ref,
-  Store,
-  Stream,
-  Text,
-  Null,
-  run
-} from "../index.js";
+import { View, Dict, Ref, Store, Stream, Text, Null, run } from "../index.js";
+
+import { Reflect } from "../reflect.js";
 
 describe("View", () => {
   function newStore() {
@@ -28,9 +20,9 @@ describe("View", () => {
     const row2 = new Dict({ col1: new Ref(["table1", "row1"]) });
     const view = new View(
       new Dict({
-        viewFn: new Field(),
+        viewFn: new Reflect.FieldFn(),
         obj: new Ref(["table1", "row2", "col1"]),
-        field: new Text("col1")
+        key: new Text("col1")
       })
     );
     table1.get("row1").replace(row1);
@@ -63,7 +55,7 @@ describe("View", () => {
     s.get("table1")
       .get("view")
       .get("info")
-      .get("field")
+      .get("key")
       .replace(new Text("col2"));
 
     expect(v.next.version).to.be.an.instanceof(Null);

--- a/db/text.js
+++ b/db/text.js
@@ -40,9 +40,7 @@ export class Text extends Value {
     }
 
     const before = this.slice(offset, offset + count);
-    const change = new Splice(offset, before, replacement);
-    const version = this.stream && this.stream.append(change);
-    return this._nextf(change, version).version;
+    return this.appendChange(new Splice(offset, before, replacement)).version;
   }
 
   /**
@@ -58,9 +56,7 @@ export class Text extends Value {
    * @return {Text}
    */
   move(offset, count, distance) {
-    const change = new Move(offset, count, distance);
-    const version = this.stream && this.stream.append(change);
-    return this._nextf(change, version).version;
+    return this.appendChange(new Move(offset, count, distance)).version;
   }
 
   /** clone makes a copy but with stream set to null */

--- a/db/value.js
+++ b/db/value.js
@@ -30,9 +30,23 @@ export class Value {
    * @returns {Value} r - r has same stream as this
    **/
   replace(replacement) {
-    const change = new Replace(this.clone(), replacement.clone());
-    const version = this.stream && this.stream.append(change);
-    return this._nextf(change, version).version;
+    return this.appendChange(new Replace(this.clone(), replacement.clone()))
+      .version;
+  }
+
+  /**
+   * appendChange applies a change to the value and the underlying stream
+   * It returns a {change, version} tuple much like next does.
+   */
+  appendChange(c) {
+    if (!this.stream) {
+      return this.apply(c).clone();
+    }
+    const n = this.stream.append(c);
+    if (!n) {
+      return this;
+    }
+    return this._nextf(n.change, n.version);
   }
 
   /** @type {Object} null or {change, version} */

--- a/db/view.js
+++ b/db/view.js
@@ -39,6 +39,26 @@ export class InvokeStream extends DerivedStream {
     this.args = args;
   }
 
+  append(c) {
+    return this._nextf(this.parent && this.parent.append(c));
+  }
+
+  reverseAppend(c) {
+    return this._nextf(this.parent && this.parent.reverseAppend(c));
+  }
+
+  _nextf(n) {
+    if (!n) {
+      return null;
+    }
+    const val = this.value
+      .apply(n.change)
+      .clone()
+      .setStream(n.version);
+    const version = new InvokeStream(this.store, this.fn, this.args, val);
+    return { change: n.change, version };
+  }
+
   _getNext() {
     const n = this.store.next;
     if (n) {

--- a/examples/bidirectional_test.js
+++ b/examples/bidirectional_test.js
@@ -44,7 +44,7 @@ describe("Bi-directional", () => {
     }
   }
 
-  it("proxies edits on filtered dictionaries", () => {
+  it("proxies edits on filtered dictionaraies", () => {
     const initial = new Dict({
       hello: new Text("world"),
       boo: new Text("goop")
@@ -55,6 +55,11 @@ describe("Bi-directional", () => {
 
     expect(filtered.get("boo")).to.be.instanceOf(Null);
     expect(filtered.get("hello").text).to.equal("world");
+
+    filtered.get("seven").replace(new Text("wonders"));
+
+    // see update reflected on the underlying dictionary
+    expect(initial.latest().get("seven").text).to.equal("wonders");
   });
 
 });


### PR DESCRIPTION
The append() interface did not allow returning a "modified" change. This is needed for derivations where the user-applied change is either not valid at all or should be modified slightly.

All the append implementations are not quite right at this point of mulitple derivations (i.e. A derives B and C; and both B & C are used to derive D; the change pushed from D will land on say B but its reflection on C will not be available yet and when it is fetched, it may not be properly applied). The implementations may actually work but more testing is needed to validate these types of issues.